### PR TITLE
Listen for fedmsg messages with a WebSocket.

### DIFF
--- a/index.html
+++ b/index.html
@@ -112,6 +112,8 @@
           console.log('load meetings');
         }
       });
+
+      $(document).ready(setup_websocket_listener);
     </script>
 
 </head>

--- a/js/fedora_apps.js
+++ b/js/fedora_apps.js
@@ -25,6 +25,8 @@
  * SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
  ***********************************************************************/
 
+var socket = null;
+
 var hostname = (function () {
     var a = document.createElement('a');
     return function (url) {
@@ -176,18 +178,24 @@ function update_fedmsg(id, category, deploy) {
             $("#message_" + id).text('');
         }
     });
+
+    // If for some reason we got disconnected from our
+    // websocket, it should have set itself to null.  If
+    // that happened, let's try reconnecting.
+    if (socket == null) {
+        setup_websocket_listener();
+    }
 }
 
 function setup_websocket_listener() {
-    //document.domain = "fedoraproject.org";
-    var socket = new WebSocket("wss://hub.fedoraproject.org:9939");
+    socket = new WebSocket("wss://hub.fedoraproject.org:9939");
 
     socket.onopen = function(e){
         // Tell the hub that we want to start receiving all messages.
         socket.send(JSON.stringify({topic: '__topic_subscribe__', body: '*'}));
     };
-    socket.onerror = function(e){};
-    socket.onclose = function(e){};
+    socket.onerror = function(e){socket=null;};
+    socket.onclose = function(e){socket=null;};
 
     // Our main callback
     socket.onmessage = function(e){


### PR DESCRIPTION
Got the proof of concept working.  Still needs some work to make it awesome.
- Messages are received via websockets
- When they come in, we refresh the local cache automatically.
- If you are viewing a particular page, that page's results are visually updated.

Some ideas or things that need work:
- Can the user turn off websockets?
- Should we only update the cache for the page their looking at?  (instead of all pages like it currently does)
- Instead of requesting all messages, can we just slide in the latest message to the list instead of hiding it and replacing it with a new (almost identical) list?
